### PR TITLE
Fix package name for .xml files

### DIFF
--- a/extract_utils.sh
+++ b/extract_utils.sh
@@ -366,7 +366,11 @@ function write_blueprint_packages() {
         BASENAME=$(basename "$FILE")
         DIRNAME=$(dirname "$FILE")
         EXTENSION=${BASENAME##*.}
-        PKGNAME=${BASENAME%.*}
+        if [ "$EXTENSION" = "xml" ]; then
+            PKGNAME=$BASENAME
+        else
+            PKGNAME=${BASENAME%.*}
+        fi
 
         # Add to final package list
         PACKAGE_LIST+=("$PKGNAME")


### PR DESCRIPTION
It doesn't generate .xml prefix for prebuilt_etc_xml packages,
so add .xml in package name to get .xml in xml packages
<br>
![photo_2021-07-23_16-38-12](https://user-images.githubusercontent.com/58323485/126773697-a9e69754-02dc-4351-8ce6-e11fb6786416.jpg)
